### PR TITLE
use the new CreateSymbolicLink in dotnet 6

### DIFF
--- a/src/Spectre.IO/Internal/File.cs
+++ b/src/Spectre.IO/Internal/File.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.IO;
+#if !NET6_0_OR_GREATER
 using System.Runtime.InteropServices;
 using Mono.Unix.Native;
+#endif
 
 namespace Spectre.IO.Internal
 {
@@ -87,6 +89,9 @@ namespace Spectre.IO.Internal
                 throw new InvalidOperationException("Detination path cannot be relative");
             }
 
+#if NET6_0_OR_GREATER
+            System.IO.File.CreateSymbolicLink(Path.FullPath, destination.FullPath);
+#else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (!Win32.CreateSymbolicLink(destination.FullPath, Path.FullPath, Win32.SymbolicLink.File))
@@ -101,6 +106,7 @@ namespace Spectre.IO.Internal
                     throw new IOException($"Could not create symbolic link from {Path.FullPath} to {destination.FullPath}");
                 }
             }
+#endif
         }
     }
 }

--- a/src/Spectre.IO/Internal/File.cs
+++ b/src/Spectre.IO/Internal/File.cs
@@ -90,7 +90,7 @@ namespace Spectre.IO.Internal
             }
 
 #if NET6_0_OR_GREATER
-            System.IO.File.CreateSymbolicLink(Path.FullPath, destination.FullPath);
+            System.IO.File.CreateSymbolicLink(destination.FullPath, Path.FullPath);
 #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/src/Spectre.IO/Internal/Native/Win32.cs
+++ b/src/Spectre.IO/Internal/Native/Win32.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿#if !NET6_0_OR_GREATER
+using System.Runtime.InteropServices;
 
 namespace Spectre.IO.Internal
 {
@@ -14,3 +15,4 @@ namespace Spectre.IO.Internal
         public static extern bool CreateSymbolicLink(string lpSymlinkFileName, string lpTargetFileName, SymbolicLink dwFlags);
     }
 }
+#endif

--- a/src/Spectre.IO/Spectre.IO.csproj
+++ b/src/Spectre.IO/Spectre.IO.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup Label="StyleCop">


### PR DESCRIPTION
Removing a native dependency for dotnet 6 👏 

This makes spectre.io more attractive has it has no dependencies and especially no native dependency for those using dotnet 6 👍

![image](https://user-images.githubusercontent.com/1661688/143390623-711e22a4-b62b-4b07-a9ef-03b104b76978.png)
